### PR TITLE
Add cmake path discovery for custom install prefix

### DIFF
--- a/cracen2Config.cmake.in
+++ b/cracen2Config.cmake.in
@@ -21,12 +21,13 @@ endif()
 ###############################################################################
 
 find_library(CRACEN2_LIB NAMES cracen2
-	PATHS "@CMAKE_INSTALL_PREFIX@"
+    PATHS "@CMAKE_INSTALL_PREFIX@/lib"
 )
 
 find_path(CRACEN2_DIR
-  NAMES include/cracen2/Cracen2.hpp
-  DOC "location for cracen2 headers"
+    PATHS "@CMAKE_INSTALL_PREFIX@"
+    NAMES "include/cracen2/Cracen2.hpp"
+    DOC "location for cracen2 headers"
 )
 if(CRACEN2_DIR)
 	set(CRACEN2_INCLUDE_DIR ${CRACEN2_DIR}/include)


### PR DESCRIPTION
When using `find_package(cracen2)` CMake was unable to find the libs and header directories if cracen2 has been installed with a custom `CMAKE_INSTALL_PREFIX`.

* I added hints to `find_path()` and `find_library()` to solve this issue.